### PR TITLE
Put badges onto a Flex Container

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>cesartalvez! Software Engineering, Languages and Everthing in between!</title>
+
+  <style>
+
+    .badges-container {
+
+      display: flex;
+      flex-direction: row;
+    }
+
+    .badges-container div {
+      width: 50%;
+    }
+  </style>
 </head>
 <body>
 
@@ -21,23 +34,22 @@
   </div>
 
   <section id="external">
-    <div class="container">
-      <div class="external">
-        <div class="linkedin-badge">
-          <div class="badge-base LI-profile-badge" data-locale="pt_BR" data-size="medium" data-theme="dark"
-            data-type="VERTICAL" data-vanity="cesartalves" data-version="v1">
-            <a class="badge-base__link LI-simple-link"
-              href="https://br.linkedin.com/in/cesartalves?trk=profile-badge"></a>
-          </div>
-        </div>
+    <div class="badges-container">
 
-        <div class="stackoveflow-badge">
-          <a href="https://stackoverflow.com/users/9744136/cesartalves">
-            <img src="https://stackoverflow.com/users/flair/9744136.png?theme=dark" width="208" height="58"
-              alt="profile for cesartalves at Stack Overflow, Q&amp;A for professional and enthusiast programmers"
-              title="profile for cesartalves at Stack Overflow, Q&amp;A for professional and enthusiast programmers">
-          </a>
+      <div class="linkedin-badge">
+        <div class="badge-base LI-profile-badge" data-locale="pt_BR" data-size="medium" data-theme="dark"
+          data-type="VERTICAL" data-vanity="cesartalves" data-version="v1">
+          <a class="badge-base__link LI-simple-link"
+            href="https://br.linkedin.com/in/cesartalves?trk=profile-badge"></a>
         </div>
+      </div>
+
+      <div class="stackoveflow-badge">
+        <a href="https://stackoverflow.com/users/9744136/cesartalves">
+          <img src="https://stackoverflow.com/users/flair/9744136.png?theme=dark" width="208" height="58"
+            alt="profile for cesartalves at Stack Overflow, Q&amp;A for professional and enthusiast programmers"
+            title="profile for cesartalves at Stack Overflow, Q&amp;A for professional and enthusiast programmers">
+        </a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
In this brief commit I divide the Social Media Badges into two columns:

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/ce82e686-1e85-464e-951f-300bc0070b93">
